### PR TITLE
without default queue arguments

### DIFF
--- a/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
+++ b/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
@@ -578,16 +578,6 @@ void StorageRabbitMQ::bindQueue(size_t queue_id, AMQP::TcpChannel & rabbit_chann
         }
     }
 
-    /// Impose default settings if there are no user-defined settings.
-    if (!queue_settings.contains("x-max-length"))
-    {
-        queue_settings["x-max-length"] = queue_size;
-    }
-    if (!queue_settings.contains("x-overflow"))
-    {
-        queue_settings["x-overflow"] = "reject-publish";
-    }
-
     /// If queue_base - a single name, then it can be used as one specific queue, from which to read.
     /// Otherwise it is used as a generator (unique for current table) of queue names, because it allows to
     /// maximize performance - via setting `rabbitmq_num_queues`.


### PR DESCRIPTION
without default queue arguments x-max-length and x-overflow.

### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in official stable or prestable release)


### Declare queue without arguments is impossible:

By default queues created without arguments. Arguments for queues are optional and 
intended for changing default behavior for interaction with queues and messages in them.
If previously queue was created without arguments, then connection to it is impossible, because
RabbitMQ returns PRECONDITION_FAILED error after queue declaration.